### PR TITLE
Actually use `options.args`

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -90,13 +90,18 @@ runLoader.pitch = function(remainingRequest: string) {
         return;
     }
 
-    const result = "(req['default'] || req).apply(req)";
+    let args: string;
+    if (opts.args) {
+        args = JSON.stringify(opts.args);
+    }
+
+    const result = "(req['default'] || req).apply(req, ${args})";
     const exports = opts.stringify
         ? `JSON.stringify(${result});`
         : `${result};`;
 
-    return `var req = require(${JSON.stringify("!!" + remainingRequest)});
-module.exports = ${exports}`;
+    return `var req = require(${JSON.stringify(remainingRequest)});`
+        + `module.exports = ${exports}`;
 }
 
 export = runLoader;


### PR DESCRIPTION
Arguments provided in `options.args` are now used in
call to exported function.