### PR TITLE
Explicit return type for argOptionSchema function

### DIFF
--- a/src/loader.ts
+++ b/src/loader.ts
@@ -77,21 +77,21 @@ function optionsSchema() {
     return joi.object({
         context: joi.func(),
         args: joi.array().items(
-            joi.lazy(() => argOptionObjectSchema())
+            joi.lazy(() => argOptionSchema())
         ),
         export: joi.boolean().default(false),
         stringify: joi.boolean().default(false)
     });
 }
 
-function argOptionObjectSchema() {
+function argOptionSchema(): joi.AlternativesSchema {
     return joi.alternatives().try(
         joi.string().allow(""),
         joi.number(),
         joi.boolean(),
         joi.any().valid(null),
-        joi.array().items(joi.lazy(() => argOptionObjectSchema())),
-        joi.object().pattern(/./, joi.lazy(() => argOptionObjectSchema()))
+        joi.array().items(joi.lazy(() => argOptionSchema())),
+        joi.object().pattern(/./, joi.lazy(() => argOptionSchema()))
     );
 }
 


### PR DESCRIPTION
Make typescript happy by explicitely stating return type
for `argOptionSchema` function since it is indirectly being
used in exported function.